### PR TITLE
make user, item, value column keys and implicit configurable

### DIFF
--- a/disco.gemspec
+++ b/disco.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "daru"
   spec.add_development_dependency "rover-df"
   spec.add_development_dependency "ngt", ">= 0.3.0"
+  spec.add_development_dependency "pry"
 end

--- a/lib/disco/recommender.rb
+++ b/lib/disco/recommender.rb
@@ -17,7 +17,7 @@ module Disco
       validation_set = to_dataset(validation_set) if validation_set
 
       # NOTE: use user-provided implicit flag or derive from train-set
-      @implicit ||= !train_set.any? { |v| v[:rating] }
+      @implicit = !train_set.any? { |v| v[:rating] } if @implicit.nil?
 
       unless @implicit
         ratings = train_set.map { |o| o[value_key] }
@@ -84,7 +84,7 @@ module Disco
 
         predictions =
           @item_map.keys.zip(predictions).map do |item_id, pred|
-            {item_id: item_id, score: pred}
+            {@item_key => item_id, score: pred}
           end
 
         if item_ids
@@ -162,7 +162,7 @@ module Disco
           result.map do |v|
             {
               # ids from batch_insert start at 1 instead of 0
-              item_id: keys[v[:id] - 1],
+              @item_key => keys[v[:id] - 1],
               # convert cosine distance to cosine similarity
               score: 1 - v[:distance]
             }
@@ -172,7 +172,7 @@ module Disco
 
           predictions =
             map.keys.zip(predictions).map do |item_id, pred|
-              {item_id: item_id, score: pred}
+              {@item_key => item_id, score: pred}
             end
 
           max_score = predictions.delete_at(i)[:score]

--- a/test/recommender_test.rb
+++ b/test/recommender_test.rb
@@ -70,6 +70,14 @@ class RecommenderTest < Minitest::Test
     ])
     recommender.user_recs(1)
     recommender.item_recs(1)
+
+    recommender = Disco::Recommender.new user_key: :username, item_key: :movie_id, value_key: :stars, implicit: false
+    recommender.fit([
+      {username: 'alice', movie_id: 1, stars: 1},
+      {username: 'bob', movie_id: 1, stars: 2}
+    ])
+    recommender.user_recs(1)
+    recommender.item_recs(1)
   end
 
   def test_validation_set_explicit

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,5 +6,6 @@ require "minitest/pride"
 require "csv"
 require "daru"
 require "rover"
+require "pry"
 
 require_relative "support/active_record"


### PR DESCRIPTION
First of all thanks for this great gem @ankane 

One limitation that I've come across is the hardcoded `user_id`, `item_id` and `value/rating` keys.

Currently, I have to transform the data I receive so that the keys in the json objects / hashes match those hardcoded values which in essence means:

1. looping over the hash
2. storing the values on the expected key
3. delete the old key.

Here is an example where I do this for a JSON object that I get back from a data analysis tool:

```
        response_json = JSON.parse(response.read_body)

        keys = [:user_id, :item_id, :rating]
        train_set = response_json.map do |record|
          Hash[keys.zip(record.values)]
        end
```

It would be great if instead I could simply pass the keys that `disco` should use to retrieve the required data so I dont have to transform my dataset to meet the hardcoded keys.

This PR does just that, it makes the `user_id`, `item_id`, `value_key` configurable in the initialization method of the disco recommender.

This will allow for use-cases like these:

```
    recommender = Disco::Recommender.new user_key: :username, item_key: :movie_id, value_key: :stars, implicit: false
    recommender.fit([
      {username: 'alice', movie_id: 1, stars: 1},
      {username: 'bob', movie_id: 1, stars: 2}
    ])
    recommender.user_recs('alice')
    recommender.item_recs(1)
```